### PR TITLE
黒文字の描画バグ修正

### DIFF
--- a/chrome-extension/20-pipVideo.js
+++ b/chrome-extension/20-pipVideo.js
@@ -127,7 +127,8 @@ const videoPipElement = document.createElement('video');
       }
 
       // canvasをクリア
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = 'black'; // 黒をセット
+      ctx.fillRect(0, 0, canvas.width, canvas.height); // 全体を塗りつぶし
 
       // nicoVideoElementを中央揃えで描画
       if (nicoVideoElement.videoWidth > 0 && nicoVideoElement.videoHeight > 0) {


### PR DESCRIPTION
#15 
描画クリア処理を透明化から黒塗りに変更
clearRectはキャンバスを透明化するが、その場合は黒文字に白い縁が付く
黒色でfillRectして背景を黒塗りにすると、意図した縁の薄い黒文字が描画できる