### PR TITLE
PIPボタンの色と位置を調整

### DIFF
--- a/chrome-extension/21-pipButton.js
+++ b/chrome-extension/21-pipButton.js
@@ -35,11 +35,21 @@ let updatePipButtonElement = null;
     pipButtonElement.style.padding = '0px';
     pipButtonElement.style.margin = '0px';
     pipButtonElement.style.border = 'none';
-    pipButtonElement.style.color = '#cccccc';
     pipButtonElement.style.backgroundColor = 'rgba(0, 0, 0, 0)';
-    pipButtonElement.style.fontSize = '16px';
+    pipButtonElement.style.fontSize = '18px';
     pipButtonElement.style.fontWeight = 'bold';
     pipButtonElement.style.cursor = 'pointer';
+    pipButtonElement.style.marginTop = '-1px'; // 上に少しずらす
+
+    // PIPボタンの色を設定
+    pipButtonElement.style.color = pipButtonOnMouseOutColor;
+    // ホバーで色を変える
+    pipButtonElement.addEventListener('mouseenter', () => {
+      pipButtonElement.style.color = pipButtonOnMouseOverColor;
+    });
+    pipButtonElement.addEventListener('mouseleave', () => {
+      pipButtonElement.style.color = pipButtonOnMouseOutColor;
+    });
 
     // ボタンをクリックしたときの処理
     pipButtonElement.addEventListener('click', pipButtonClickCallback);


### PR DESCRIPTION
#2 
* コントローラーにある他のオリジナルボタンに合わせて実装
  * ホバー時に色が変わる処理を追加
  * フォントサイズを18pxに変更
  * アイコンの位置を1px上にずらす処理を追加